### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "find-google-docs-in-string",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "find-google-docs-in-string",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "find-google-docs-in-string",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "🔨 Find links from Google Docs in string or file",
     "license": "MIT",
     "author": {
@@ -13,7 +13,8 @@
         "prebuild": "rm -rf dist/ types/",
         "build": "tsc",
         "test": "vitest run",
-        "coverage": "vitest run --coverage"
+        "coverage": "vitest run --coverage",
+        "prepublishOnly": "npm run build"
     },
     "dependencies": {
         "minimist": "^1.2.8"


### PR DESCRIPTION
Release after the TypeScript migration (adds type declarations + compiled dist, non-breaking → minor). Adds prepublishOnly build safeguard.